### PR TITLE
FACES-2996 Unified all ResourceBundle.getBundle usages so UTF8Control can be moved to internal

### DIFF
--- a/src/main/java/com/liferay/faces/util/i18n/I18n.java
+++ b/src/main/java/com/liferay/faces/util/i18n/I18n.java
@@ -78,4 +78,19 @@ public interface I18n {
 	 *                       pattern.
 	 */
 	public String getMessage(FacesContext facesContext, Locale locale, String messageId, Object... arguments);
+
+	/**
+	 * Creates (if necessary) and returns an internationalized {@link String} message based on the specified {@code
+	 * locale}, {@code messageId}. If the message contains a {@link java.text.MessageFormat} pattern then the specified
+	 * {@code arguments} are inserted into the message accordingly.
+	 *
+	 * @param  facesContext  The current faces context.
+	 * @param  bundleKey     The resource bundle baseName.
+	 * @param  locale        The locale of the message.
+	 * @param  messageId     The id of the message.
+	 * @param  arguments     The values that are to be inserted according to the {@link java.text.MessageFormat}
+	 *                       pattern.
+	 */
+	public String getMessage(FacesContext facesContext, String bundleKey, Locale locale, String messageId,
+		Object... arguments);
 }

--- a/src/main/java/com/liferay/faces/util/i18n/I18nBundleBase.java
+++ b/src/main/java/com/liferay/faces/util/i18n/I18nBundleBase.java
@@ -88,37 +88,16 @@ public abstract class I18nBundleBase extends I18nWrapper implements Serializable
 		}
 		else {
 
-			ResourceBundle resourceBundle = null;
-
 			try {
 				String bundleKey = getBundleKey();
 
-				if (locale == null) {
-					resourceBundle = ResourceBundle.getBundle(bundleKey, new UTF8Control());
-				}
-				else {
-					resourceBundle = ResourceBundle.getBundle(bundleKey, locale, new UTF8Control());
-				}
+				message = super.getMessage(facesContext, bundleKey, locale, messageId, new Object[] {});
+				messageCache.put(key, message);
 			}
 			catch (MissingResourceException e) {
 				logger.error(e);
+				messageCache.put(key, "");
 			}
-
-			if (resourceBundle != null) {
-
-				try {
-					message = resourceBundle.getString(messageId);
-					messageCache.put(key, message);
-				}
-				catch (MissingResourceException e) {
-					messageCache.put(key, "");
-				}
-			}
-		}
-
-		if (message == null) {
-
-			message = super.getMessage(facesContext, locale, messageId);
 		}
 
 		return message;

--- a/src/main/java/com/liferay/faces/util/i18n/I18nWrapper.java
+++ b/src/main/java/com/liferay/faces/util/i18n/I18nWrapper.java
@@ -63,4 +63,13 @@ public abstract class I18nWrapper implements I18n, FacesWrapper<I18n> {
 	public String getMessage(FacesContext facesContext, Locale locale, String messageId, Object... arguments) {
 		return getWrapped().getMessage(facesContext, locale, messageId, arguments);
 	}
+
+	/**
+	 * See {@link I18n#getMessage(FacesContext, String, Locale, String, Object...)}
+	 */
+	@Override
+	public String getMessage(FacesContext facesContext, String bundleKey, Locale locale, String messageId,
+		Object... arguments) {
+		return getWrapped().getMessage(facesContext, bundleKey, locale, messageId, arguments);
+	}
 }

--- a/src/main/java/com/liferay/faces/util/i18n/internal/I18nImpl.java
+++ b/src/main/java/com/liferay/faces/util/i18n/internal/I18nImpl.java
@@ -30,7 +30,6 @@ import javax.faces.context.FacesContext;
 
 import com.liferay.faces.util.i18n.I18n;
 import com.liferay.faces.util.i18n.I18nUtil;
-import com.liferay.faces.util.i18n.UTF8Control;
 
 
 /**
@@ -64,11 +63,25 @@ public class I18nImpl implements I18n, Serializable {
 
 	@Override
 	public String getMessage(FacesContext facesContext, Locale locale, String messageId, Object... arguments) {
+		return getMessage(facesContext, "i18n", locale, messageId, arguments);
+	}
+
+	@Override
+	public String getMessage(FacesContext facesContext, String bundleKey, Locale locale, String messageId,
+		Object... arguments) {
 
 		String message = null;
 
 		try {
-			ResourceBundle resourceBundle = ResourceBundle.getBundle("i18n", locale, new UTF8Control());
+			ResourceBundle resourceBundle = null;
+
+			if (locale == null) {
+				resourceBundle = ResourceBundle.getBundle(bundleKey, new UTF8Control());
+			}
+			else {
+				resourceBundle = ResourceBundle.getBundle(bundleKey, locale, new UTF8Control());
+			}
+
 			message = resourceBundle.getString(messageId);
 		}
 		catch (MissingResourceException e) {

--- a/src/main/java/com/liferay/faces/util/i18n/internal/UTF8Control.java
+++ b/src/main/java/com/liferay/faces/util/i18n/internal/UTF8Control.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.liferay.faces.util.i18n;
+package com.liferay.faces.util.i18n.internal;
 
 import java.io.IOException;
 import java.io.InputStream;


### PR DESCRIPTION
Hi @ngriffin7a, I think this refactor won't cause any harm and looks more intuitive and unified.

EDIT: Please backport to all branches too.