### PR TITLE
FACES-2311 Store cache in a classloader based map for FactoryExtensionFinder (to avoid bridge API change), store in applicationMap otherwise.

### DIFF
--- a/src/main/java/com/liferay/faces/util/application/ApplicationUtil.java
+++ b/src/main/java/com/liferay/faces/util/application/ApplicationUtil.java
@@ -15,6 +15,9 @@
  */
 package com.liferay.faces.util.application;
 
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
 import javax.faces.context.ExternalContext;
 import javax.faces.context.FacesContext;
 
@@ -25,6 +28,20 @@ import javax.faces.context.FacesContext;
 public final class ApplicationUtil {
 
 	private ApplicationUtil() {
+	}
+
+	@SuppressWarnings("unchecked")
+	public static Map<String, Object> getOrCreateApplicationCache(FacesContext facesContext, String cacheName) {
+		Map<String, Object> applicationMap = facesContext.getExternalContext().getApplicationMap();
+
+		Map<String, Object> cache = (Map<String, Object>) applicationMap.get(cacheName);
+
+		if (cache == null) {
+			cache = new ConcurrentHashMap<String, Object>();
+			applicationMap.put(cacheName, cache);
+		}
+
+		return cache;
 	}
 
 	/**

--- a/src/main/java/com/liferay/faces/util/config/WebConfigParamUtil.java
+++ b/src/main/java/com/liferay/faces/util/config/WebConfigParamUtil.java
@@ -15,12 +15,13 @@
  */
 package com.liferay.faces.util.config;
 
-import java.util.HashMap;
 import java.util.Map;
 
 import javax.faces.context.ExternalContext;
+import javax.faces.context.FacesContext;
 import javax.servlet.ServletContext;
 
+import com.liferay.faces.util.application.ApplicationUtil;
 import com.liferay.faces.util.helper.BooleanHelper;
 import com.liferay.faces.util.helper.IntegerHelper;
 import com.liferay.faces.util.helper.LongHelper;
@@ -34,14 +35,12 @@ import com.liferay.faces.util.helper.LongHelper;
  */
 public class WebConfigParamUtil {
 
-	// Note: Performance is faster with a synchronized block around HashMap.put(String, Object) rather than using a
-	// ConcurrentHashMap.
-	private static final Map<String, Object> configParamCache = new HashMap<String, Object>();
-
 	public static boolean getBooleanValue(ExternalContext externalContext, String name, String alternateName,
 		boolean defaultBooleanValue) {
 
 		boolean booleanValue = defaultBooleanValue;
+
+		Map<String, Object> configParamCache = getConfigParamCache();
 
 		Object cachedValue = configParamCache.get(name);
 
@@ -55,9 +54,7 @@ public class WebConfigParamUtil {
 				booleanValue = BooleanHelper.isTrueToken(configuredValue);
 			}
 
-			synchronized (configParamCache) {
-				configParamCache.put(name, Boolean.valueOf(booleanValue));
-			}
+			configParamCache.put(name, Boolean.valueOf(booleanValue));
 		}
 
 		return booleanValue;
@@ -79,6 +76,8 @@ public class WebConfigParamUtil {
 
 		int integerValue = defaultIntegerValue;
 
+		Map<String, Object> configParamCache = getConfigParamCache();
+
 		Object cachedValue = configParamCache.get(name);
 
 		if ((cachedValue != null) && (cachedValue instanceof Integer)) {
@@ -91,9 +90,7 @@ public class WebConfigParamUtil {
 				integerValue = IntegerHelper.toInteger(configuredValue);
 			}
 
-			synchronized (configParamCache) {
-				configParamCache.put(name, Integer.valueOf(integerValue));
-			}
+			configParamCache.put(name, Integer.valueOf(integerValue));
 		}
 
 		return integerValue;
@@ -103,6 +100,8 @@ public class WebConfigParamUtil {
 		long defaultLongValue) {
 
 		long longValue = defaultLongValue;
+
+		Map<String, Object> configParamCache = getConfigParamCache();
 
 		Object cachedValue = configParamCache.get(name);
 
@@ -116,9 +115,7 @@ public class WebConfigParamUtil {
 				longValue = LongHelper.toLong(configuredValue);
 			}
 
-			synchronized (configParamCache) {
-				configParamCache.put(name, Long.valueOf(longValue));
-			}
+			configParamCache.put(name, Long.valueOf(longValue));
 		}
 
 		return longValue;
@@ -128,6 +125,8 @@ public class WebConfigParamUtil {
 		String defaultStringValue) {
 
 		String stringValue = defaultStringValue;
+
+		Map<String, Object> configParamCache = getConfigParamCache();
 
 		Object cachedValue = configParamCache.get(name);
 
@@ -141,9 +140,7 @@ public class WebConfigParamUtil {
 				stringValue = configuredValue;
 			}
 
-			synchronized (configParamCache) {
-				configParamCache.put(name, stringValue);
-			}
+			configParamCache.put(name, stringValue);
 		}
 
 		return stringValue;
@@ -151,5 +148,12 @@ public class WebConfigParamUtil {
 
 	public static boolean isSpecified(ExternalContext externalContext, String name, String alternateName) {
 		return (getConfiguredValue(externalContext, name, alternateName) != null);
+	}
+
+	private static Map<String, Object> getConfigParamCache() {
+		FacesContext facesContext = FacesContext.getCurrentInstance();
+		String cacheName = WebConfigParamUtil.class.getName();
+
+		return ApplicationUtil.getOrCreateApplicationCache(facesContext, cacheName);
 	}
 }

--- a/src/main/java/com/liferay/faces/util/el/internal/I18nMap.java
+++ b/src/main/java/com/liferay/faces/util/el/internal/I18nMap.java
@@ -15,17 +15,16 @@
  */
 package com.liferay.faces.util.el.internal;
 
-import java.io.IOException;
 import java.util.Collection;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
 
 import javax.faces.application.Application;
 import javax.faces.component.UIViewRoot;
 import javax.faces.context.FacesContext;
 
+import com.liferay.faces.util.application.ApplicationUtil;
 import com.liferay.faces.util.i18n.I18n;
 import com.liferay.faces.util.i18n.I18nFactory;
 
@@ -37,9 +36,6 @@ public class I18nMap extends I18nMapCompat {
 
 	// serialVersionUID
 	private static final long serialVersionUID = 5549598732411060854L;
-
-	// Private Data Members
-	private transient Map<String, String> cache = new ConcurrentHashMap<String, String>();
 
 	@Override
 	public void clear() {
@@ -89,13 +85,15 @@ public class I18nMap extends I18nMapCompat {
 					messageKey = locale.toString().concat(keyAsString);
 				}
 
-				message = cache.get(messageKey);
+				Map<String, Object> messageCache = getMessageCache();
+
+				message = (String) messageCache.get(messageKey);
 
 				if (message == null) {
 					message = i18n.getMessage(facesContext, locale, keyAsString);
 
 					if (message != null) {
-						cache.put(messageKey, message);
+						messageCache.put(messageKey, message);
 					}
 				}
 			}
@@ -252,7 +250,10 @@ public class I18nMap extends I18nMapCompat {
 		throw new UnsupportedOperationException();
 	}
 
-	private void readObject(java.io.ObjectInputStream in) throws IOException, ClassNotFoundException {
-		cache = new ConcurrentHashMap<String, String>();
+	private Map<String, Object> getMessageCache() {
+		FacesContext facesContext = FacesContext.getCurrentInstance();
+		String cacheName = I18nMap.class.getName();
+
+		return ApplicationUtil.getOrCreateApplicationCache(facesContext, cacheName);
 	}
 }

--- a/src/main/java/com/liferay/faces/util/factory/FactoryExtensionFinder.java
+++ b/src/main/java/com/liferay/faces/util/factory/FactoryExtensionFinder.java
@@ -68,4 +68,6 @@ public abstract class FactoryExtensionFinder {
 	public abstract Object getFactoryInstance(Class<?> clazz);
 
 	public abstract void registerFactory(ConfiguredElement configuredFactoryExtension);
+
+	public abstract void releaseFactories();
 }

--- a/src/main/java/com/liferay/faces/util/i18n/internal/I18nImpl.java
+++ b/src/main/java/com/liferay/faces/util/i18n/internal/I18nImpl.java
@@ -15,19 +15,18 @@
  */
 package com.liferay.faces.util.i18n.internal;
 
-import java.io.IOException;
 import java.io.Serializable;
 import java.text.MessageFormat;
 import java.util.Locale;
 import java.util.Map;
 import java.util.MissingResourceException;
 import java.util.ResourceBundle;
-import java.util.concurrent.ConcurrentHashMap;
 
 import javax.faces.application.Application;
 import javax.faces.application.FacesMessage;
 import javax.faces.context.FacesContext;
 
+import com.liferay.faces.util.application.ApplicationUtil;
 import com.liferay.faces.util.i18n.I18n;
 import com.liferay.faces.util.i18n.I18nUtil;
 
@@ -39,10 +38,6 @@ public class I18nImpl implements I18n, Serializable {
 
 	// serialVersionUID
 	private static final long serialVersionUID = 707385608167301726L;
-
-	// Private Data Members
-	private transient Map<Locale, ResourceBundle> facesResourceBundleCache =
-		new ConcurrentHashMap<Locale, ResourceBundle>();
 
 	@Override
 	public FacesMessage getFacesMessage(FacesContext facesContext, Locale locale, FacesMessage.Severity severity,
@@ -118,7 +113,8 @@ public class I18nImpl implements I18n, Serializable {
 
 	private ResourceBundle getFacesResourceBundle(FacesContext facesContext, Locale locale) {
 
-		ResourceBundle facesResourceBundle = facesResourceBundleCache.get(locale);
+		Map<String, Object> facesResourceBundleCache = getFacesResourceBundleCache();
+		ResourceBundle facesResourceBundle = (ResourceBundle) facesResourceBundleCache.get(locale.toString());
 
 		if (facesResourceBundle == null) {
 
@@ -130,13 +126,16 @@ public class I18nImpl implements I18n, Serializable {
 			}
 
 			facesResourceBundle = ResourceBundle.getBundle(messageBundle, locale, new UTF8Control());
-			facesResourceBundleCache.put(locale, facesResourceBundle);
+			facesResourceBundleCache.put(locale.toString(), facesResourceBundle);
 		}
 
 		return facesResourceBundle;
 	}
 
-	private void readObject(java.io.ObjectInputStream stream) throws IOException, ClassNotFoundException {
-		facesResourceBundleCache = new ConcurrentHashMap<Locale, ResourceBundle>();
+	private Map<String, Object> getFacesResourceBundleCache() {
+		FacesContext facesContext = FacesContext.getCurrentInstance();
+		String cacheName = I18nImpl.class.getName();
+
+		return ApplicationUtil.getOrCreateApplicationCache(facesContext, cacheName);
 	}
 }


### PR DESCRIPTION
Hi @ngriffin7a. So this is working fine (would work perfect after https://github.com/brianchandotcom/liferay-portal/pull/46918 is merged).

I used ApplicationMap (servletContext) for those cache usages that were made involved in JSF. Just used a classloader approach for storing in the only one that could be executed prior to any JSF phase (FactoryFinder). This approach is similar to the one made in Mojarra. The only drawback of using a cache with classloader as key is that should be cleared manually, and BridgeSessionListener.contextDestroyed is the best for this case (similar behavior on Mojarra too).

If liferay-faces-util is shared, it shouldn't cause any problem as each application will release their factories (used from their classloaders).

It's very advisable to use this whenever previous mentioned Liferay 7 pull is merged and released, so we ensure all code under BridgeSessionListener.sessionDestroyed is made before BridgeSessionListener.contextDestroyed. This doesn't affect Liferay 6.2, as that is made on the app server itself.

Thanks!